### PR TITLE
Fix source file name error

### DIFF
--- a/source/data/input.cpp
+++ b/source/data/input.cpp
@@ -203,7 +203,7 @@ QString EGSInput::buildInput() {
 	output = output + "\t\tname         = lib_source\n";
 	output = output + "\t\tlibrary      = egs_isotropic_source\n";
 	output = output + "\t\tcharge       = 0\n";
-	output = output + "\t\tinclude file = " + sourceShapeFile + "\n";
+	output = output + "\t\tinclude file = " + sourceSeedFile + "\n";
 	output = output + "\t\t:start spectrum:\n";
 	output = output + "\t\t\ttype          = tabulated spectrum\n";
 	output = output + "\t\t\tspectrum file = " + sourceSpecFile + "\n";

--- a/source/data/input.h
+++ b/source/data/input.h
@@ -67,7 +67,7 @@ public:
 	QString VC_density, VC_type, VC_bound, VC_thresh;
 	
 	// source definition
-	QString sourceTransFile, sourceSpecFile, sourceShapeFile, sourceDwells;
+	QString sourceTransFile, sourceSpecFile, sourceShapeFile, sourceSeedFile, sourceDwells;
 	
 	// scoring options
 	QString SO_edep, SO_muenFile, SO_muenMed, SO_scale;

--- a/source/interface.cpp
+++ b/source/interface.cpp
@@ -1039,6 +1039,13 @@ int Interface::populateEgsinp() {
 		egsinp->sourceSpecFile = data->eb_location+"/lib/spectra/Pd103_NNDC_2.6_line.spectrum"; // Pre-set parameter
 	else
 		egsinp->sourceSpecFile = data->eb_location+"/lib/spectra/I125_NCRP_line.spectrum"; // Pre-set parameter
+
+        s = sourceListView->currentItem()->text();
+        if (s.endsWith("_wrapped"))
+                s.chop(8);
+        i = data->libNameSources.indexOf(s);
+        s = data->libDirSources[i]+s;
+        egsinp->sourceSeedFile = s+".shape"; // GUI parameter
 	
 	s = sourceListView->currentItem()->text();
 	i = data->libNameSources.indexOf(s);


### PR DESCRIPTION
Fixed a bug that included the seed's geometry.shape file in the source definition block rather than the seed.shape file in order to ensure the correct rad