### PR TITLE
Fixed problem with source.shape pathname.

### DIFF
--- a/source/interface.cpp
+++ b/source/interface.cpp
@@ -1042,7 +1042,7 @@ int Interface::populateEgsinp() {
 
         s = sourceListView->currentItem()->text();
         if (s.endsWith("_wrapped"))
-                s.chop(8);
+                s.chop(9);
         i = data->libNameSources.indexOf(s);
         s = data->libDirSources[i]+s;
         egsinp->sourceSeedFile = s+".shape"; // GUI parameter


### PR DESCRIPTION
For wrapped sources, 9 characters need to be removed, not 8 as in previous change.